### PR TITLE
Remove project call from CompilerFlags module

### DIFF
--- a/experiments/CompilerFlags.cmake
+++ b/experiments/CompilerFlags.cmake
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.16)
 
 include_guard(GLOBAL)
 
-project(compiler_flags VERSION 1.1.0)
-
 ########################################################################
 # define a virtual library target for propagation of compiler flags  
 


### PR DESCRIPTION
This is intended to be included in projects and thus should not set a project name, because that will override the name set for the including projects.