### PR TITLE
fix README and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CMake Utilities is a collection of utilities which help escaping the dependency 
 
 It extends CMake's [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html) feature such that all dependency information is collected in a separate file in the top-level of the repository, thereby avoiding repetitive code in the CMake files and enabling efficient configuration management.
 
-In addition, these utilities provide support for developers to apply code changes distributed across dependencies and the dependent code base. When configured accordingly, these utilities will put dependencies (and dependencies of dependencies) outside the standard [`${CMAKE_BINARY_DIR}`](https://cmake.org/cmake/help/latest/variable/CMAKE_BINARY_DIR.html#cmake-binary-dir)`/_deps` structure to a user-defined place in the filesystem. The dependency hierarchy tree gets unfolded into a flat structure.  Debugging information will be adapted accordingly. It is possible to have mutiple build directories point to the very same codebase.
+In addition, these utilities provide support for developers to apply code changes distributed across dependencies and the dependent code base. When configured accordingly, these utilities will put dependencies (and dependencies of dependencies) outside the standard [`${CMAKE_BINARY_DIR}`](https://cmake.org/cmake/help/latest/variable/CMAKE_BINARY_DIR.html#cmake-binary-dir)`/_deps` structure to a user-defined place in the filesystem. The dependency hierarchy tree gets unfolded into a flat structure.  Debugging information will be adapted accordingly. It is possible to have multiple build directories point to the very same codebase.
 
 Although this project was designed to meet the needs of C++ developers, extra effort went into not having any dependency beyond CMake itself, so this project can be used in other context, e.g. as a drop-in replacement for [`svn externals`](https://svnbook.red-bean.com/en/1.7/svn.advanced.externals.html) in a git project.      
 
@@ -103,7 +103,7 @@ target_link_libraries(
     fmt::fmt
 )
 
-# Only build an run tests if this project is compiled as top-level project
+# Only build and run tests if this project is compiled as a top-level project
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     enable_testing()
     add_subdirectory(test-catch)
@@ -132,7 +132,7 @@ catch2 GIT_REPOSITORY https://github.com/catchorg/Catch2 GIT_TAG v2.x
 fmt GIT_REPOSITORY https://github.com/fmtlib/fmt GIT_TAG master
 ```
 
-This file is read and parsed by the utilities. The first line of the file always must contain the file format version information. As of today this is `Version: v1.0.0`. This makes the information stored in this file robust against future changes of the utilities.     
+This file is read and parsed by the utilities. The first line of the file always must contain the file format version information. As of today, this is `Version: v1.0.0`. This makes the information stored in this file robust against future changes of the utilities.     
 
 Comments must be prepended with a `#` symbol. Empty lines are ignored. Please ensure that there is [a newline at the end of file to avoid surprises](https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file).
 
@@ -183,9 +183,9 @@ catch_discover_tests(test_tool_1)
 
 ## Editing Code and Debugging
 
-CMake's [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html) feature is rather limited when code changes are required not only in the top-level project, but also in dependencies. CMake pulls all files into a subdirectory of the build directory, namely [`${CMAKE_BINARY_DIR}`](https://cmake.org/cmake/help/latest/variable/CMAKE_BINARY_DIR.html#cmake-binary-dir)`/_deps`. There they are under version control, but may be overwritten without question on subsequent cmake calls - or accidentally deleted by the user when cleaning up the build directory. This makes code editing and tracking changes a pain. Also, building and debugging multiple variants (e.g. differing in compiler flags) requires to download or clone all dependencies multiple times into different build directories. This does not scale well with large dependency trees.
+CMake's [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html) feature is rather limited when code changes are required not only in the top-level project, but also in dependencies. CMake pulls all files into a subdirectory of the build directory, namely [`${CMAKE_BINARY_DIR}`](https://cmake.org/cmake/help/latest/variable/CMAKE_BINARY_DIR.html#cmake-binary-dir)`/_deps`. There they are under version control, but may be overwritten without question on subsequent CMake calls - or accidentally deleted by the user when cleaning up the build directory. This makes code editing and tracking changes a pain. Also, building and debugging multiple variants (e.g. differing in compiler flags) requires to download or clone all dependencies multiple times into different build directories. This does not scale well with large dependency trees.
 
-With the utilities presented here this is easily overcome. In addition, it is guaranteed that the network traffic *and* the disc usage are both minimized - at least for one top level project. For multiple top level projects one has to take extra measures based on the options presented here.
+With the utilities presented here this is easily overcome. In addition, it is guaranteed that the network traffic *and* the disc usage are both minimized - at least for one top-level project. For multiple top-level projects one has to take extra measures based on the options presented here.
 
 All one has to do is declare a deviation from the standard CMake behavior and set a custom filesystem location (directory) for the so-called workspace, i.e. the place where all dependencies are copied to on the filesystem. As a user, you have several choices:
 
@@ -201,7 +201,7 @@ set(REPOMAN_DEPENDENCIES_USE_WORKSPACE ON CACHE BOOL "")
 set(REPOMAN_DEPENDENCIES_WORKSPACE "ws" CACHE PATH "")
 ```
 
-Given these settings, the initial run of the `cmake` command with populate all dependencies into [`${CMAKE_PROJECT_NAME}`](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_NAME.html#cmake-project-name)`/ws` into a flat structure. All dependencies and all dependencies of dependencies mentioned in the top level `dependencies.txt` file will reside in dedicated subdirectories side by side.   
+Given these settings, the initial run of the `cmake` command with populate all dependencies into [`${CMAKE_PROJECT_NAME}`](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_NAME.html#cmake-project-name)`/ws` into a flat structure. All dependencies and all dependencies of dependencies mentioned in the top-level `dependencies.txt` file will reside in dedicated subdirectories side by side.   
 
 ```bash
 .../tool_1/build$ tree -L 2 ..
@@ -266,7 +266,7 @@ Setting the path relatively without adding a directory name, like e.g.
 ```cmake
 set(REPOMAN_DEPENDENCIES_WORKSPACE "../" CACHE PATH "") 
 ```
-will use an automatically generated directory name and place it besides the current project directory [`${CMAKE_PROJECT_NAME}`](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_NAME.html#cmake-project-name).
+will use and automatically generated directory name and place it besides the current project directory [`${CMAKE_PROJECT_NAME}`](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_NAME.html#cmake-project-name).
 
 ```bash
 tool_1/build$ tree -L 2 ../..
@@ -333,7 +333,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
 Built target repoman-status
 ```
 
-Note that all git dependencies are cloned in detached state. One can switch to a specific branch, e.g. 
+Note that all git dependencies are cloned in a detached state. One can switch to a specific branch, e.g. 
 
 ```bash
 tool_1/build$ cd ../ws/lib_A/
@@ -361,7 +361,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
 Built target repoman-status
 ```
 
-This feature helps you keep track of all changes made across all dependencies. For future versions of this utility project it is planned to add further bulk operations like e.g. creating a branch. In the meantime a workaround is using [`git-bulk`](https://github.com/nschlimm/git-bulk).
+This feature helps you keep track of all changes made across all dependencies. For future versions of this utility project, it is planned to add further bulk operations like e.g. creating a branch. In the meantime, a workaround is using [`git-bulk`](https://github.com/nschlimm/git-bulk).
 
 ## Some Remarks
 

--- a/RepoMan.cmake
+++ b/RepoMan.cmake
@@ -51,10 +51,10 @@ Alternatively, you can also include it via add_subdirectory() or provide it via 
 
   FetchContent_MakeAvailable(cmake_utilities)
 
-You can also run the RepoManResolve.cmake script as a command directly from the command line. This also works for non-CMake projects. This s called ``script mode``, in contrast to ``project mode``, which is the normal usage of the module though a CMake project file.
+You can also run the RepoManResolve.cmake script as a command directly from the command line. This also works for non-CMake projects. This is called ``script mode``, in contrast to ``project mode``, which is the normal usage of the module through a CMake project file.
 
 
-In oder to actually do anything, the project root directory must contain a ``dependencies. txt`` file or a file with a different name, if ``REPOMAN_DEPENDENCIES_FILE_NAME`` is set accordingly.
+In order to actually do anything, the project root directory must contain a ``dependencies. txt`` file or a file with a different name, if ``REPOMAN_DEPENDENCIES_FILE_NAME`` is set accordingly.
 This file must contain one line for each dependency, in the format given to ``FetchContent()``. All arguments of ``FetchContent()`` are supported. Empty and commented lines are also allowed and will be ignored.
 
 Each dependency defined this way will be provided and included via ``add_subdirectory()``. Any sub-dependencies in a dependency's ``dependencies.txt`` will also be added. If a dependency has already been defined in a parent project, that definition takes precedence, so higher-level projects can override their child dependency's requirements.
@@ -70,7 +70,7 @@ The following variables modify the behaviour of the module. They are set to reas
   Use the workspace defined by ``REPOMAN_DEPENDENCIES_WORKSPACE`` for dependency sources instead of the default FetchContent directories. This allows easier editing of dependency sources. Defaults to ``ON`` in script mode and ``OFF`` in project mode.
 
 .. variable:: REPOMAN_DEPENDENCIES_WORKSPACE
-  Where to put the dependency sources. This can be either empty, a name, a relative path or an absolute path.
+  Where to put the dependency sources. This can be either empty, a name, a relative path, or an absolute path.
 
   An empty string will use the defaults: a directory name generated from the current project directory, in the current project's parent directory.
   A name will use that given name, in the current project directory.
@@ -206,7 +206,7 @@ function(repoman__internal__handle_dependencies DIRECTORY)
 
             list(APPEND REPOMAN_DEPENDENCIES ${REPOMAN_DEPENDENCY_NAME})
 
-            # Set depedencvy directories
+            # Set depedency directories
             if(REPOMAN_DEPENDENCIES_USE_WORKSPACE)
                 set(DEPENDENCY_SOURCE_DIR ${REPOMAN_WORKSPACE}/${REPOMAN_DEPENDENCY_NAME})
             else()


### PR DESCRIPTION
Update of mostly typos and for more consistency
not complete list:
* `cmake` in texts -> `CMake`
* `top level` -> `top-level` (both versions existed prior)
* some missing letters (mu(l)tiple, an(d), etc)
* etc